### PR TITLE
Fix compile errors on modern ESPHome versions

### DIFF
--- a/components/whirlpool_ac/climate.py
+++ b/components/whirlpool_ac/climate.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate_ir
-from esphome.const import CONF_ID, CONF_MODEL
+from esphome.const import CONF_MODEL
 from esphome.components import switch
 
 AUTO_LOAD = ["climate_ir", "switch"]
@@ -22,13 +22,10 @@ MODELS = {
 CONF_IR_TRANSMITTER_SWITCH = "ir_transmitter_switch"
 CONF_IFEEL_SWITCH = "ifeel_switch"
 
-SWITCH_SCHEMA = switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
-    {cv.GenerateID(): cv.declare_id(WhirlpoolACSwitch)}
-)
+SWITCH_SCHEMA = switch.switch_schema(WhirlpoolACSwitch).extend(cv.COMPONENT_SCHEMA)
 
-CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(WhirlpoolAC).extend(
     {
-        cv.GenerateID(): cv.declare_id(WhirlpoolAC),
         cv.Optional(CONF_MODEL, default="DG11J1-3A"): cv.enum(MODELS, upper=True),
         cv.Optional(CONF_IR_TRANSMITTER_SWITCH): SWITCH_SCHEMA,
         cv.Optional(CONF_IFEEL_SWITCH): SWITCH_SCHEMA,
@@ -36,13 +33,11 @@ CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(
 )
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    await climate_ir.register_climate_ir(var, config)
+    var = await climate_ir.new_climate_ir(config)
     cg.add(var.set_model(config[CONF_MODEL]))
     for s in [CONF_IR_TRANSMITTER_SWITCH, CONF_IFEEL_SWITCH]:
         if s in config:
             conf = config[s]
-            a_switch = cg.new_Pvariable(conf[CONF_ID])
+            a_switch = await switch.new_switch(conf)
             await cg.register_component(a_switch, conf)
-            await switch.register_switch(a_switch, conf)
             cg.add(getattr(var, f"set_{s}")(a_switch))


### PR DESCRIPTION
Hi, there was a compilation error when trying to compile this project

```
INFO ESPHome 2026.3.1
INFO Reading configuration /config/esphome/xxxxx.yaml...
ERROR Unable to load component whirlpool_ac.climate:
Traceback (most recent call last):
  File "/esphome/esphome/loader.py", line 211, in _lookup_module
    module = importlib.import_module(f"esphome.components.{domain}")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/data/external_components/a098277c/components/whirlpool_ac/climate.py", line 25, in <module>
    SWITCH_SCHEMA = switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
                    ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'esphome.components.switch' has no attribute 'SWITCH_SCHEMA'. Did you mean: '_SWITCH_SCHEMA'?
Failed config

```

I fixed it by doing the following changes:

- Replaced deprecated SWITCH_SCHEMA and CLIMATE_IR_WITH_RECEIVER_SCHEMA with modern class-based schema functions.

- Updated component registration to use modern await new_climate_ir() and await new_switch() methods.

- Removed unused CONF_ID import in climate.py.